### PR TITLE
ftb无尽之心文本描述错误修复，ftb补充灾厄猎杀事件介绍

### DIFF
--- a/config/ftbquests/quests/chapters/1048F50BAEFE652C.snbt
+++ b/config/ftbquests/quests/chapters/1048F50BAEFE652C.snbt
@@ -497,7 +497,7 @@
 		{
 			dependencies: ["24E73A64F055728A"]
 			description: [
-				"无尽节律在你没有手持物品、没有装备胸甲时，每次攻击会额外提供2的&2临时攻击力&r加成，可&6无限叠加&r。"
+				"无尽节律在你没有手持物品、没有装备胸甲时，每次攻击会额外提供4的&2临时攻击力&r加成，可&6无限叠加&r。"
 				""
 				"代价是，&2每次攻击自身会受到等同于增加攻击力的固定伤害&r。"
 				""
@@ -3564,6 +3564,35 @@
 			title: "杂项特殊器官"
 			x: -8.75d
 			y: 28.25d
+		}
+		{
+			description: [
+				"这是一只兔子，谁会忍心伤害一只可爱的兔子呢？将它放进胸腔，你将免于灾厄猎杀事件的针对。"
+				"但是，针对你好友的灾厄猎杀仍有可能会波及到你。"
+			]
+			icon: {
+				Count: 1b
+				id: "kubejs:is_rabbit"
+				tag: { }
+			}
+			id: "3772E8A85AD5D276"
+			rewards: [{
+				id: "3ABC6E84B8433017"
+				item: "lightmanscurrency:coin_gold"
+				type: "item"
+			}]
+			subtitle: "这真的只是一只兔子？"
+			tasks: [{
+				id: "1AD6378FE8C6E353"
+				item: {
+					Count: 1b
+					id: "kubejs:is_rabbit"
+					tag: { }
+				}
+				type: "item"
+			}]
+			x: -3.75d
+			y: 29.25d
 		}
 	]
 	title: "胸腔：器官收集指南"

--- a/config/ftbquests/quests/chapters/5732E8BABFC7D570.snbt
+++ b/config/ftbquests/quests/chapters/5732E8BABFC7D570.snbt
@@ -735,6 +735,32 @@
 			x: 6.5d
 			y: 3.25d
 		}
+		{
+			description: [
+				"就在你因为深入探索诡厄巫法的秘密而欣喜若狂时，危险也悄然来临。灾厄村民不会放过任何一个试图盗取诡厄魔法的人，一支由精英灾厄村民组成的小队已被派出，他们会猎杀任何染指了禁忌魔法之人。"
+				"当你的&4灵魂能量&r高于一个阈值时，将有概率引发一场高强度的袭击事件。"
+				"但或许有些办法能够阻止这场猎杀？"
+			]
+			icon: "goety:spent_totem"
+			id: "0EDCC4CAAA82198E"
+			rewards: [{
+				id: "191D251916C147CD"
+				item: {
+					Count: 1b
+					id: "kubejs:is_rabbit"
+					tag: { }
+				}
+				type: "item"
+			}]
+			subtitle: "万事皆有其代价"
+			tasks: [{
+				id: "7452E8CC5FFFDCFF"
+				title: "灾厄袭击"
+				type: "checkmark"
+			}]
+			x: -3.5d
+			y: 2.0d
+		}
 	]
 	title: "诡厄巫法：潜藏在黑魔法的力量"
 }


### PR DESCRIPTION
无尽之心器官描述和实际效果的临时攻击力是4，ftb原本是2.
灾厄猎杀事件在引导中没有提到，现已补充，查看后顺便获取兔子。