### PR TITLE
一些修复与修改

### DIFF
--- a/kubejs/assets/kubejs/lang/zh_cn.json
+++ b/kubejs/assets/kubejs/lang/zh_cn.json
@@ -958,6 +958,7 @@
     "kubejs.tooltips.evolution": "进化",
     "kubejs.tooltips.food": "食物",
     "kubejs.tooltips.active_only": "唯一激活",
+    "kubejs.tooltips.auto_active": "自动激活",
     "kubejs.tooltips.rclick_only": "唯一右键点击",
     "kubejs.tooltips.rclick": "右键点击",
     "kubejs.tooltips.player_tick_only": "唯一玩家刻",

--- a/kubejs/client_scripts/default_organ_tooltips.js
+++ b/kubejs/client_scripts/default_organ_tooltips.js
@@ -1,5 +1,6 @@
 function DefaultOrgan(itemID) {
     this.itemID = itemID
+    this.pseudoOrgan = false
     this.organScores = []
     this.defaultTextLines = []
     this.shiftTextLines = []
@@ -18,6 +19,10 @@ DefaultOrgan.prototype = {
             let typeName = global.SCORE_MAP[score.id]
             this.shiftTextLines.push([LEADING_SYMBOL, Text.gray(Text.translatable("kubejs.tooltips.organ_score.1")), Text.yellow(String(value)), Text.gray(Text.translatable("kubejs.tooltips.organ_score.2")), Text.yellow(typeName)])
         })
+        return this
+    },
+    setPseudo: function (boolean) {
+        this.pseudoOrgan = boolean
         return this
     },
 }
@@ -73,6 +78,9 @@ ItemEvents.tooltip((tooltip) => {
         }
     })
 
+    /**
+     * @param {DefaultOrgan} organ 
+     */
     function registerDefaultOrganToolTips(organ) {
         tooltip.addAdvanced(organ.itemID, (item, advanced, text) => {
             text.removeIf(e => {
@@ -111,21 +119,21 @@ ItemEvents.tooltip((tooltip) => {
                     }
 
                     lineNum = addForTextLines(text, organ.defaultTextLines, lineNum);
-                    if (organ.shiftTextLines && organ.shiftTextLines.length != 0) {
+                    if (organ.shiftTextLines && organ.shiftTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).gold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.4")).yellow().bold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.5")).gold(),
                         ]);
                     }
-                    if (organ.ctrlTextLines && organ.ctrlTextLines.length != 0) {
+                    if (organ.ctrlTextLines && organ.ctrlTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).aqua(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.6")).yellow().bold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.7")).aqua(),
                         ]);
                     }
-                    if (organ.altTextLines && organ.altTextLines.length != 0) {
+                    if (organ.altTextLines && organ.altTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).red(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.8")).yellow().bold(),
@@ -259,4 +267,25 @@ ItemEvents.tooltip((tooltip) => {
     registerDefaultOrganToolTips(new DefaultOrgan('chestcavity:small_carnivore_stomach').addScore('carnivorous_digestion', 0.75).addScore('herbivorous_digestion', 0.25).build())
     registerDefaultOrganToolTips(new DefaultOrgan('chestcavity:small_animal_spine').addScore('defense', 0.375).addScore('nerves', 0.5).build())
     registerDefaultOrganToolTips(new DefaultOrgan('chestcavity:small_carnivore_intestine').addScore('carnivorous_nutrition', 0.75).addScore('herbivorous_nutrition', 0.25).build())
+
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:beef').addScore('strength', 0.75).addScore('speed', 0.75).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:mutton').addScore('strength', 0.75).addScore('speed', 0.75).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:tnt').addScore('explosive', 1024).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:gunpowder').addScore('explosive', 192).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:rotten_flesh').addScore('strength', 0.5).addScore('speed', 0.5).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:obsidian').addScore('defense', 0.5).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:crying_obsidian').addScore('defense', 0.5).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:netherite_block').addScore('luck', 1.25).addScore('defense', 2).addScore('buoyant', -1.5).addScore('speed', -1.5).addScore('fire_resistant', 4).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:iron_block').addScore('defense', 2).addScore('buoyant', -1).addScore('speed', -1).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:iron_bars').addScore('defense', 1.25).addScore('buoyant', -0.5).addScore('speed', -0.25).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:gold_block').addScore('luck', 1.25).addScore('buoyant', -1).addScore('speed', -1).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:glowstone_dust').addScore('glowing', 64).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:glowstone').addScore('glowing', 128).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:emerald_block').addScore('luck', 1).addScore('buoyant', -1).addScore('speed', -1).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:diamond_block').addScore('luck', 1.25).addScore('defense', 2).addScore('buoyant', -1).addScore('speed', -1).addScore('fire_resistant', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:bone_block').addScore('defense', 0.75).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:bone').addScore('defense', 0.5).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:blaze_rod').addScore('pyromancy', 1).addScore('hydroallergenic', 1).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:pork').addScore('strength', 0.75).addScore('speed', 0.75).setPseudo(true).build())
+    registerDefaultOrganToolTips(new DefaultOrgan('minecraft:dirt').addScore('luck', 0.037037).addScore('health', 0.037037).addScore('strength', 0.296296).addScore('speed', 0.296296).addScore('nerves', 0.037037).addScore('detoxification', 0.037037).addScore('filtration', 0.074074).addScore('breath_capacity', 0.074074).addScore('breath_recovery', 0.074074).addScore('endurance', 0.074074).addScore('metabolism', 0.037037).addScore('digestion', 0.037037).addScore('nutrition', 0.148148).addScore('defense', 0.1666666).setPseudo(true).build())
 })

--- a/kubejs/client_scripts/organ_tooltips.js
+++ b/kubejs/client_scripts/organ_tooltips.js
@@ -48,21 +48,21 @@ ItemEvents.tooltip((tooltip) => {
                     }
 
                     lineNum = addForTextLines(text, organ.defaultTextLines, lineNum);
-                    if (organ.shiftTextLines && organ.shiftTextLines.length != 0) {
+                    if (organ.shiftTextLines && organ.shiftTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).gold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.4")).yellow().bold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.5")).gold(),
                         ]);
                     }
-                    if (organ.ctrlTextLines && organ.ctrlTextLines.length != 0) {
+                    if (organ.ctrlTextLines && organ.ctrlTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).aqua(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.6")).yellow().bold(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.7")).aqua(),
                         ]);
                     }
-                    if (organ.altTextLines && organ.altTextLines.length != 0) {
+                    if (organ.altTextLines && organ.altTextLines.length != 0 && !organ.pseudoOrgan) {
                         text.add(lineNum++, [
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.3")).red(),
                             Text.of(Text.translatable("kubejs.tooltips.organ_score.8")).yellow().bold(),

--- a/kubejs/server_scripts/champion/entity_spawned.js
+++ b/kubejs/server_scripts/champion/entity_spawned.js
@@ -4,15 +4,32 @@ EntityEvents.spawned(event => {
     */
     let entity = event.entity
     if (!entity || !entity.isLiving() || !entity.isMonster()) return
-    
+
+    /** @type {String[]} */
+    let typeList = entity.persistentData.get('champion') ?? []
     let player = entity.getLevel().getNearestPlayer(entity, 64)
     if (!player) return
     let warp = player.persistentData.getInt(warpCount)
-    if (warp < 20) return
-    if (Math.random() > 0.001 * warp) return
-    let randomChampionType = randomGet(championTypeMap)
-    entity.persistentData.put('champion', [randomChampionType.type])
-    entity.setCustomName([randomChampionType.name, Text.gray('精英')])
+    while (true) {
+        if (warp < 20 || Math.random() > 0.001 * warp || typeList.length >= championTypeMap.length) break
+        let randomChampionType = randomGet(championTypeMap)
+        if (typeList.find((value, index, obj) => (value == randomChampionType.type))) continue
+        typeList.push(randomChampionType.type)
+    }
+
+    if (!typeList || typeList.length < 1) return
+    let typeNameList = []
+    typeList.forEach(type => {
+        championTypeMap.forEach(cha => {
+            if (cha.type == type) {
+                typeNameList.push(cha.name)
+                typeNameList.push(Text.gray('·'))
+            }
+        })
+    });
+    typeNameList.push(Text.gray('精英'))
+    entity.persistentData.put('champion', typeList)
+    entity.setCustomName(new Component.join(typeNameList))
     entity.setCustomNameVisible(true)
 })
 

--- a/kubejs/server_scripts/common/food_eaten.js
+++ b/kubejs/server_scripts/common/food_eaten.js
@@ -1,38 +1,12 @@
-ItemEvents.foodEaten('cataclysm:blessed_amethyst_crab_meat', event => {
+ItemEvents.foodEaten(event => {
     let player = event.player
-    if (!player) return
+    let item = event.item
+    if (!player || !item || !item.id in warpFoodMap) return
     let warp = player.persistentData.getInt(warpCount)
-    if (warp > 0) {
-        updateWarpCount(player, warp - 3)
-        player.tell(Text.darkAqua(Text.translatable("kubejs.msg.warp.2")))
-    }
-})
-
-ItemEvents.foodEaten('chestcavity:raw_man_meat', event => {
-    let player = event.player
-    if (!player) return
-    if (Math.random() > 0.1) return
-    let warp = player.persistentData.getInt(warpCount)
-    updateWarpCount(player, warp + 1)
-    player.tell(Text.darkPurple(Text.translatable("kubejs.msg.warp.1")))
-})
-
-ItemEvents.foodEaten('extradelight:bad_food', event => {
-    let player = event.player
-    if (!player) return
-    if (Math.random() > 0.05) return
-    let warp = player.persistentData.getInt(warpCount)
-    updateWarpCount(player, warp + 1)
-    player.tell(Text.darkPurple(Text.translatable("kubejs.msg.warp.1")))
-})
-
-
-ItemEvents.foodEaten('minecraft:enchanted_golden_apple', event => {
-    let player = event.player
-    if (!player) return
-    let warp = player.persistentData.getInt(warpCount)
-    if (warp > 0) {
-        updateWarpCount(player, warp - 1)
-        player.tell(Text.darkAqua(Text.translatable("kubejs.msg.warp.2")))
+    let count = warpFoodMap[item.id].count
+    let chance = warpFoodMap[item.id].chance
+    if (Math.random() <= chance) {
+        updateWarpCount(player, warp + count)
+        player.tell(Text.darkAqua(Text.translatable(`kubejs.msg.warp.${count > 0 ? 1 : 2}`)))
     }
 })

--- a/kubejs/server_scripts/common/item_right.js
+++ b/kubejs/server_scripts/common/item_right.js
@@ -22,6 +22,10 @@ ItemEvents.rightClicked('kubejs:unbreakable_core', event => {
         return
     }
     let unbreakone = player.getMainHandItem()
+    if (unbreakone?.nbt && unbreakone.nbt?.Unbreakable) {
+        player.tell('该物品已进行过不毁加持！')
+        return
+    }
     if (!unbreakone.hasEnchantment('minecraft:unbreaking', 1)) {
         player.tell('不满足耐久要求！')
         return

--- a/kubejs/server_scripts/common/tags.js
+++ b/kubejs/server_scripts/common/tags.js
@@ -14,11 +14,10 @@ ServerEvents.tags('item', event => {
   event.add('kubejs:candy_focus', ['kubejs:candy_bag'])
   event.add('irons_spellbooks:school_focus', ['minecraft:nether_star', 'kubejs:candy_bag'])
 
-  event.add('kubejs:isb_spell_book', ['irons_spellbooks:netherite_spell_book', 'irons_spellbooks:diamond_spell_book', 'irons_spellbooks:gold_spell_book', 'irons_spellbooks:iron_spell_book', 'irons_spellbooks:copper_spell_book', 'irons_spellbooks:rotten_spell_book', 'irons_spellbooks:blaze_spell_book', 'irons_spellbooks:dragonskin_spell_book', 'irons_spellbooks:druidic_spell_book',
-    'irons_spellbooks:villager_spell_book', 'irons_spellbooks:blood_staff', 'irons_spellbooks:evoker_spell_book'])
+  event.add('kubejs:isb_spell_book', ['irons_spellbooks:wimpy_spell_book', 'irons_spellbooks:legendary_spell_book', 'irons_spellbooks:netherite_spell_book', 'irons_spellbooks:diamond_spell_book', 'irons_spellbooks:gold_spell_book', 'irons_spellbooks:iron_spell_book', 'irons_spellbooks:copper_spell_book', 'irons_spellbooks:rotten_spell_book', 'irons_spellbooks:blaze_spell_book', 'irons_spellbooks:dragonskin_spell_book', 'irons_spellbooks:druidic_spell_book', 'irons_spellbooks:villager_spell_book', 'irons_spellbooks:blood_staff', 'irons_spellbooks:evoker_spell_book', 'irons_spellbooks:necronomicon_spell_book', 'kubejs:command_spell_book'])
 
   event.add('curios:body', ['supplementaries:quiver'])
-  
+
 
   event.add('kubejs:lung', ['chestcavity:lung', 'chestcavity:rotten_lung', 'chestcavity:animal_lung', 'chestcavity:llama_lung', 'chestcavity:fireproof_lung', 'chestcavity:small_animal_lung', 'chestcavity:insect_lung', 'chestcavity:ender_lung', 'chestcavity:dragon_lung', 'chestcavity:saltwater_lung', 'chestcavity:gas_bladder'])
 
@@ -41,12 +40,13 @@ ServerEvents.tags('item', event => {
 
   event.add('forge:sausage', ['chestcavity:raw_sausage', 'chestcavity:sausage', 'chestcavity:raw_rich_sausage', 'chestcavity:rich_sausage', 'chestcavity:raw_mini_sausage', 'chestcavity:mini_sausage', 'chestcavity:raw_rich_mini_sausage', 'chestcavity:rich_mini_sausage', 'chestcavity:rotten_sausage', 'chestcavity:raw_toxic_sausage', 'chestcavity:toxic_sausage', 'chestcavity:raw_rich_toxic_sausage', 'chestcavity:rich_toxic_sausage', 'chestcavity:raw_human_sausage', 'chestcavity:human_sausage', 'chestcavity:raw_rich_human_sausage', 'chestcavity:rich_human_sausage', 'chestcavity:raw_alien_sausage', 'chestcavity:alien_sausage', 'chestcavity:raw_rich_alien_sausage', 'chestcavity:rich_alien_sausage', 'chestcavity:raw_dragon_sausage', 'chestcavity:dragon_sausage', 'chestcavity:raw_rich_dragon_sausage', 'chestcavity:rich_dragon_sausage', 'kubejs:brown_sauce_braised_intestines'])
 
-  event.add('forge:rabbit/ground/raw', ['minecraft:rabbit'])
-  
-
   const baseorgan = event.get('chestcavity:salvageable').getObjectIds()
   baseorgan.forEach(organ => {
     event.add('kubejs:organ', organ)
   })
 
+})
+
+ServerEvents.tags('minecraft:entity_type', event => {
+  event.add('forge:rabbit/ground/raw', ['minecraft:rabbit'])
 })

--- a/kubejs/server_scripts/event_stream.js
+++ b/kubejs/server_scripts/event_stream.js
@@ -29,7 +29,7 @@ global.LivingHurtByPlayer = event => {
     organCharmEntityHurtByPlayer(event, data)
     championEntityHurtByPlayer(event, data)
     if (data.returnDamage != 0) {
-        player.attack(data.returnDamage)
+        player.attack(data.damageSource, data.returnDamage)
     }
 }
 
@@ -52,7 +52,7 @@ global.LivingDamageByOthers = event => {
     sweetDreamPlayerHurtByOthers(event, data)
     curiosPlayerHurtByOthers(event, data)
     if (data.returnDamage != 0 && event.source.actual) {
-        event.source.actual.attack(data.returnDamage)
+        event.source.actual.attack(data.damageSource, data.returnDamage)
     }
 }
 

--- a/kubejs/server_scripts/organ/active_effect.js
+++ b/kubejs/server_scripts/organ/active_effect.js
@@ -94,7 +94,7 @@ function clearAllActivedModify(player) {
 function attributeMapValueAddition(attributeMap, attribute, modifyValue) {
     if (attributeMap.has(attribute.name)) {
         if (attribute.operation == 'multiply_total') {
-            modifyValue = modifyValue * attributeMap.get(attribute.name)
+            modifyValue = (1 + modifyValue) * (1 + attributeMap.get(attribute.name)) - 1
         }
         else {
             modifyValue = modifyValue + attributeMap.get(attribute.name)
@@ -337,7 +337,7 @@ const organActiveStrategies = {
             attributeMapValueAddition(attributeMap, global.LUCK_MULTI_BASE, 0.1)
         }
     }
-};
+}
 
 /**
  * 器官激活唯一策略
@@ -450,7 +450,7 @@ const organActiveOnlyStrategies = {
         let chestInventoryTypeMap = getPlayerChestCavityTypeMap(player)
         chestInventoryTypeMap.delete('kubejs:rose')
         for (let i = 0; i < chestInventory.length; i++) {
-            let organ = chestInventory[i];
+            let organ = chestInventory[i]
             let itemId = String(organ.getString('id'))
             let tagList = Item.of(itemId).getTags().toArray()
             for (let i = 0; i < tagList.length; i++) {

--- a/kubejs/server_scripts/organ/chest_cavity_manager.js
+++ b/kubejs/server_scripts/organ/chest_cavity_manager.js
@@ -49,7 +49,13 @@ PlayerEvents.inventoryClosed((event) => {
     if (player.persistentData.contains(organActive) && player.persistentData.getInt(organActive) == 1) {
         return
     }
-    if (itemMap.has('kubejs:long_lasting_pill') || itemMap.has('kubejs:long_lasting_pill_gold')) {
+    let activeFlag = false
+    global.pillList.forEach(pill => {
+        if (itemMap.has(pill)) {
+            activeFlag = true
+        }
+    })
+    if (activeFlag) {
         global.updatePlayerActiveStatus(event.player)
         player.persistentData.putInt(organActive, 1)
     }

--- a/kubejs/server_scripts/organ/chest_cavity_manager.js
+++ b/kubejs/server_scripts/organ/chest_cavity_manager.js
@@ -50,8 +50,10 @@ PlayerEvents.inventoryClosed((event) => {
         return
     }
     let activeFlag = false
-    global.pillList.forEach(pill => {
-        if (itemMap.has(pill)) {
+    itemMap.forEach(organ => {
+        if (player.getChestCavityInstance().inventory.hasAnyMatching(item => {
+            return item.hasTag('kubejs:auto_active')
+        })) {
             activeFlag = true
         }
     })

--- a/kubejs/server_scripts/organ/key_bind.js
+++ b/kubejs/server_scripts/organ/key_bind.js
@@ -152,7 +152,7 @@ const organPlayerKeyPressedOnlyStrategies = {
         if (itemMap.has('minecraft:tnt')) {
             cooldown = cooldown + itemMap.get('minecraft:tnt').length * 10
         }
-        player.potionEffects.add('goety:explosive', Math.max(60, 20 * duration), Math.max(Math.min(2, Math.floor(amplifier))), 0)
+        player.potionEffects.add('goety:explosive', Math.max(60, 20 * duration), Math.max(Math.min(2, Math.floor(amplifier))), false, false)
         player.addItemCooldown('kubejs:excited_appendix', Math.max(20 * 10, 20 * (120 - cooldown)))
     },
     'kubejs:blood_crystal': function (event, organ) {
@@ -324,11 +324,11 @@ const organPlayerKeyPressedOnlyStrategies = {
         let level = event.level
         let player = event.player
         let randomPosBlock = player.block.offset((0.5 - Math.random()) * 1000, (128 - Math.random() * 32) - player.block.y, (0.5 - Math.random()) * 1000)
-        
+
         let luck = Math.max(player.getLuck(), 0)
         let table = 'minecraft:chests/stronghold/base'
         let dimLootMap = treasureDetectorTableMap[level.dimensionKey.location()]
-        
+
         if (dimLootMap) {
             let keys = Object.keys(dimLootMap)
             keys.forEach((a) => parseInt(a))

--- a/kubejs/server_scripts/utils/constdef.js
+++ b/kubejs/server_scripts/utils/constdef.js
@@ -240,3 +240,22 @@ const treasureDetectorTableMap = {
 }
 
 const machineChestLootTable = ['kubejs:platelet_dispatcher', 'kubejs:lowlight_vision', 'kubejs:revolution_relay', 'kubejs:revolution_delay', 'kubejs:rose_quartz_muscle', 'kubejs:revolution_cable', 'kubejs:revolution_gear', 'kubejs:rose_quartz_dialyzer', 'kubejs:rose_quartz_liver', 'kubejs:rose_quartz_heart', 'kubejs:revolution_steam_engine', 'kubejs:lava_life_cycle_system', 'kubejs:energy_bottle_max', 'kubejs:aegis', 'kubejs:mace', 'kubejs:machine_clockwork', 'kubejs:tamagotchi', 'kubejs:jet_propeller', 'kubejs:platelet_dispatcher', 'kubejs:compressed_oxygen_implant']
+
+const warpFoodMap = {
+    'cataclysm:blessed_amethyst_crab_meat': {
+        count: -3,
+        chance: 1,
+    },
+    'minecraft:enchanted_golden_apple': {
+        count: -1,
+        chance: 1,
+    },
+    'chestcavity:raw_man_meat': {
+        count: 1,
+        chance: 0.1,
+    },
+    'extradelight:bad_food': {
+        count: 1,
+        chance: 0.05,
+    },
+}

--- a/kubejs/server_scripts/utils/entity_hurt_model.js
+++ b/kubejs/server_scripts/utils/entity_hurt_model.js
@@ -3,5 +3,6 @@
  */
 function EntityHurtCustomModel() {
     this.returnDamage = 0
+    this.damageSource = DamageSource.GENERIC
 }
 

--- a/kubejs/startup_scripts/global.js
+++ b/kubejs/startup_scripts/global.js
@@ -123,6 +123,7 @@ global.TYPE_MAP = {
     'kubejs:bear': Text.gold(Text.translatable("kubejs.tooltips.bear")),
     'kubejs:enchant_only': Text.gold(Text.translatable("kubejs.tooltips.enchant_only")),
     'kubejs:enchant': Text.gold(Text.translatable("kubejs.tooltips.enchant")),
+    'kubejs:auto_active': Text.gold(Text.translatable("kubejs.tooltips.auto_active")),
 }
 
 
@@ -294,6 +295,3 @@ global.organCharmNbtMap = {
     'kubejs:fish_in_chest': { type: 'warp', warpTask: { warpMin: 50 }, targetOrgan: 'kubejs:fish_in_warp' },
     'chestcavity:gas_bladder': { type: 'warp', warpTask: { warpMin: 30 }, targetOrgan: 'kubejs:warp_bubble' },
 }
-
-
-global.pillList = ['kubejs:long_lasting_pill', 'kubejs:long_lasting_pill_gold']

--- a/kubejs/startup_scripts/global.js
+++ b/kubejs/startup_scripts/global.js
@@ -294,3 +294,6 @@ global.organCharmNbtMap = {
     'kubejs:fish_in_chest': { type: 'warp', warpTask: { warpMin: 50 }, targetOrgan: 'kubejs:fish_in_warp' },
     'chestcavity:gas_bladder': { type: 'warp', warpTask: { warpMin: 30 }, targetOrgan: 'kubejs:warp_bubble' },
 }
+
+
+global.pillList = ['kubejs:long_lasting_pill', 'kubejs:long_lasting_pill_gold']

--- a/kubejs/startup_scripts/item_register.js
+++ b/kubejs/startup_scripts/item_register.js
@@ -313,7 +313,7 @@ StartupEvents.registry('item', event => {
             }
             global.initChestCavityIntoMap(entity, true)
             if (entity.getChestCavityInstance().inventory.hasAnyMatching(item => {
-                return pillList.some(ele => ele == item.id.toString())
+                return global.pillList.some(ele => ele == item.id.toString())
             })) {
                 global.updatePlayerActiveStatus(entity)
                 entity.persistentData.putInt(organActive, 1)

--- a/kubejs/startup_scripts/item_register.js
+++ b/kubejs/startup_scripts/item_register.js
@@ -313,7 +313,7 @@ StartupEvents.registry('item', event => {
             }
             global.initChestCavityIntoMap(entity, true)
             if (entity.getChestCavityInstance().inventory.hasAnyMatching(item => {
-                return global.pillList.some(ele => ele == item.id.toString())
+                return item.hasTag('kubejs:auto_active')
             })) {
                 global.updatePlayerActiveStatus(entity)
                 entity.persistentData.putInt(organActive, 1)

--- a/kubejs/startup_scripts/organ_register.js
+++ b/kubejs/startup_scripts/organ_register.js
@@ -1430,7 +1430,8 @@ StartupEvents.registry('item', event => {
         .build())
         .texture('kubejs:item/organs/others/long_lasting_pill')
         .tag('itemborders:iron')
-        .tag('kubejs:evolution');
+        .tag('kubejs:evolution')
+        .tag('kubejs:auto_active');
 
     registerOrgan(new Organ('kubejs:long_lasting_pill_gold')
         .addScore('luck', 1)
@@ -1438,7 +1439,8 @@ StartupEvents.registry('item', event => {
         .addTextLines('alt', [LEADING_SYMBOL, Text.gray(Text.translatable("kubejs.tooltips.long_lasting_pill_gold.1"))])
         .build())
         .texture('kubejs:item/organs/others/long_lasting_pill')
-        .tag('itemborders:gold');
+        .tag('itemborders:gold')
+        .tag('kubejs:auto_active');
 
     registerOrgan(new Organ('kubejs:d8')
         .addScore('luck', 1)

--- a/kubejs/startup_scripts/utils/constdef.js
+++ b/kubejs/startup_scripts/utils/constdef.js
@@ -1,7 +1,6 @@
 const $ChestCavityUtil = Java.loadClass("net.tigereye.chestcavity.util.ChestCavityUtil")
 const luckyCookieSentence = ['你有些发胖了', '梦想将会实现', '你将遇到重要的人', '你将面临挑战', '尊重他的选择', '与他人分享快乐是好事', '勇敢面对挑战', '最美丽的祝福', '困倦不如先睡去吧', '未来的自己会解决的', '今天或许可以多加把劲', '尝试走向未知领域', '学会观察自己的长处', '或许可以试试侧卧睡觉', '该吃些清淡的食物', '少下矿，多睡觉', '可以尝试一些未接触过的', '释放自身压抑的欲望', '放弃也是一个好选择', '下雨的日子可以带伞', '跑步可以改善你的心情', '有氧运动有益健康', '少食多餐是长寿之道', '改变日常的习惯', '追寻新的奇迹', '新的未来在等待着你']
 
-const pillList = ['kubejs:long_lasting_pill', 'kubejs:long_lasting_pill_gold']
 const organActive = 'organActive'
 
 function randomGet(list) {

--- a/kubejs/startup_scripts/utils/organ_model.js
+++ b/kubejs/startup_scripts/utils/organ_model.js
@@ -34,8 +34,8 @@ Organ.prototype = {
         return this
     },
 
-    pseudo: function () {
-        this.pseudoOrgan = true;
+    setPseudo: function (boolean) {
+        this.pseudoOrgan = boolean
         return this
     },
 


### PR DESCRIPTION
Additions:
- 为伪器官添加器官数值显示
- - 默认不显示，需要按住shift才会显示

Changes:
- 允许多词条精英怪的生成，同时避免通过其他方式添加的精英怪词条被覆盖
- 完善tags
- 修改长效药丸的逻辑，使得社区开发者能够更加方便地添加类似器官
- 添加不毁核心的提示
- 修改食用食物导致扭曲值升降的逻辑

Fixes:
- 修复激发式阑尾无法使用按键技能的问题
- 修复（我的）上个提交中的一处算法问题