### PR TITLE
Migrate modpack to Create 6 (MC 1.20.1 + Forge 47.3.12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /hmclversion.cfg
 /config/inventoryprofilesnext/*
 !/config/inventoryprofilesnext/inventoryprofiles.json
+/dist/

--- a/KNOWNISSUE.md
+++ b/KNOWNISSUE.md
@@ -1,5 +1,84 @@
 # 当前已知问题 - Know Issue
 
+## Create 6 迁移说明 - Create 6 Migration Notes
+
+> **目标版本**: Minecraft 1.20.1 + Forge 47.3.12 + Create 6.0.8
+>
+> This section tracks the remaining manual steps needed to complete the Create 6 migration.
+> KubeJS scripts have been updated automatically; the items below require manual action.
+
+### ✅ 已完成的脚本更新 (Completed Script Updates)
+
+- `kubejs/server_scripts/recipes/create.js`:
+  - Fixed `Fluid.water(n)` → `Fluid.of('minecraft:water').withAmount(n)`
+  - Updated sequenced assembly step methods from `event.recipes.createDeploying/createCutting/createPressing()` to `event.recipes.create.deploying/cutting/pressing()` (full namespace form)
+- `kubejs/server_scripts/recipes/ore_excavation.js`:
+  - Rewrote for Create Ore Excavation 1.20+ API: vein definitions are now split into separate `vein()` calls; `Item.of().withChance()` replaced with `coeutil.processingOutput()`
+- `kubejs/startup_scripts/creative_tab_register.js`:
+  - Migrated from `dev.architectury.registry.CreativeTabRegistry` to `StartupEvents.registry('creative_mode_tab', ...)`
+- `kubejs/startup_scripts/item_register.js`, `organ_register.js`, `special/eye_finder.js`:
+  - Fixed creative tab group IDs from `"kubejs.organs"` / `"kubejs.item"` to `"kubejs:organs"` (colon namespace)
+- `kubejs/startup_scripts/special/eye_finder.js`:
+  - Updated `net.minecraft.core.Registry.STRUCTURE_REGISTRY` → `net.minecraft.core.registries.Registries.STRUCTURE` (1.20.1 API)
+- `kubejs/startup_scripts/isb/school_register.js`:
+  - Added `.setDamageType('minecraft:magic')` to both spell schools (required by irons_spells_js 1.20.1+)
+
+### ⚠️ 需要手动完成的步骤 (Manual Steps Required)
+
+#### 1. 重新生成启动器 Manifest (Regenerate Launcher Manifest)
+`No Flesh Within Chest.json` 是 Forge 安装程序生成的启动器配置文件，其中包含所有 Forge 库文件的 SHA1 哈希值。
+必须通过运行 **Forge 1.20.1 (版本 47.3.12) 安装程序** 重新生成此文件，否则启动器将无法正确下载依赖项。
+
+The launcher manifest contains SHA1 hashes for all Forge library JARs, which cannot be manually updated.
+Run the **Forge 1.20.1-47.3.12 installer** to regenerate the full launcher profile, then replace the library/download sections in this file.
+
+游戏参数 (game arguments) 已更新为 1.20.1 版本信息，但 `libraries` 和 `assetIndex` 部分仍需从安装程序重新生成。
+
+#### 2. 更新所有 Mod JAR 文件 (Update All Mod JARs)
+以下是需要从 1.19.2 更新到 1.20.1 版本的核心 Mod 文件。
+
+**Create 生态圈 (必须更新)**:
+| 旧文件 | 新版本 | 来源 |
+|--------|--------|------|
+| `create-1.19.2-0.5.1.f.jar` | `create-1.20.1-6.0.8.jar` | Forge 1.20.1 |
+| `create_central_kitchen-1.19.2-for-create-0.5.1.f-1.3.11.c.jar` | `create-central-kitchen-1.4.3b-for-create-1.20.1-6.0.6.jar` | CurseForge |
+| `createaddition-1.19.2-1.2.3.jar` | `createaddition-forge-1.20.1-1.3.3.jar` | CurseForge/Modrinth |
+| `createoreexcavation-1.19-1.2.3.jar` | Create Ore Excavation `1.20.1-1.6.5` | Modrinth |
+| `create_crystal_clear-0.2.1-1.19.2.jar` | (需要确认 1.20.1 版本) | — |
+
+**KubeJS 生态圈 (必须更新)**:
+| 旧文件 | 新版本 |
+|--------|--------|
+| `kubejs-forge-1902.6.2-build.69.jar` | KubeJS Forge `2001.6.5-build.16` |
+| `kubejs-create-forge-1902.2.4-build.36.jar` | KubeJS Create Forge `2001.3.0-build.8` |
+| `rhino-forge-1902.2.3-build.284.jar` | Rhino Forge `2001.x` (KubeJS 依赖) |
+| `ponderjs-1.19.2-1.2.0.jar` | PonderJS Forge `1.20.1-1.4.0` |
+
+**需要额外添加的 Mod**:
+- `flywheel-forge-1.20.1-1.x.x.jar` — Create 6 uses **Flywheel 1.0** (separate mod, bundled with Create JAR)
+- Ponder library — bundled with Create 6 JAR, no longer needed as separate `ponderjs-*` mod
+
+**其他 Mod** (all 160+ other mods also need 1.20.1-compatible versions):
+- 大多数知名 Mod 已有 1.20.1 版本，需逐一检查并更新
+- 以下 Mod 为核心机制依赖，需优先确认 1.20.1 兼容性:
+  - `chestcavity-forge-*.jar` → **已有** 1.20.1 Forge 版本 (v2.17.1.1)
+  - `irons_spellbooks-*.jar` → **已有** 1.20.1 版本 (v1.20.1-3.15.6)
+  - `biomancy-forge-*.jar` → 需确认
+  - `hexerei-*.jar` → 需确认
+  - `art_of_forging-*.jar` → 需确认
+
+#### 3. 确认配置文件兼容性 (Verify Config Compatibility)
+- `config/create-common.toml`: Create 6 新增了许多配置项（包裹系统、链式传送带等），建议在首次启动后让 Create 重新生成配置文件
+- `config/flywheel-client.toml`: Flywheel 1.0 的配置格式发生了变化，建议删除旧配置让其重新生成
+- 其他 Mod 配置文件: 大多数配置文件在版本迁移时会向后兼容，但建议备份后进行测试
+
+#### 4. 数据包验证 (Datapack Validation)
+迁移完成后，建议使用 `/data verify` 检查所有数据包是否正常加载，重点检查:
+- `kubejs/server_scripts/recipes/ore_excavation.js` 中的新 vein 定义格式
+- `kubejs/server_scripts/recipes/create.js` 中所有 sequenced assembly 配方
+
+
+
 > 下文仅提供中文文案用于开发团队进行问题同步。问题记录在问题发现的版本下，如若修复使用二级列表标注修复情况和方法。问题通过P0~P3等级标注优先级。
 
 ## 版本 Beta 0.0.1

--- a/No Flesh Within Chest.json
+++ b/No Flesh Within Chest.json
@@ -53,13 +53,13 @@
       "--launchTarget",
       "forgeclient",
       "--fml.forgeVersion",
-      "43.3.5",
+      "47.3.12",
       "--fml.mcVersion",
-      "1.19.2",
+      "1.20.1",
       "--fml.forgeGroup",
       "net.minecraftforge",
       "--fml.mcpVersion",
-      "20220805.130853"
+      "20230612.114412"
     ],
     "jvm": [
       {
@@ -1812,8 +1812,8 @@
   },
   "mainClass": "cpw.mods.bootstraplauncher.BootstrapLauncher",
   "minimumLauncherVersion": 21,
-  "releaseTime": "2022-08-05T19:57:05+08:00",
-  "time": "2022-08-05T19:57:05+08:00",
+  "releaseTime": "2023-06-12T19:57:05+08:00",
+  "time": "2023-06-12T19:57:05+08:00",
   "type": "release",
-  "clientVersion": "1.19.2"
+  "clientVersion": "1.20.1"
 }

--- a/kubejs/server_scripts/recipes/create.js
+++ b/kubejs/server_scripts/recipes/create.js
@@ -9,7 +9,7 @@ ServerEvents.recipes(event => {
 	}
 
 
-	event.recipes.create.mixing(Fluid.of('kubejs:syrup').withAmount(50), [Fluid.water(50), 'minecraft:sugar', 'hexerei:dried_mugwort_flowers', 'hexerei:dried_belladonna_flowers']).heated()
+	event.recipes.create.mixing(Fluid.of('kubejs:syrup').withAmount(50), [Fluid.of('minecraft:water').withAmount(50), 'minecraft:sugar', 'hexerei:dried_mugwort_flowers', 'hexerei:dried_belladonna_flowers']).heated()
 
 	event.recipes.create.filling('kubejs:hamimelon_organ', ['fruitsdelight:hamimelon', Fluid.of('kubejs:syrup').withAmount(1000)])
 	event.recipes.create.filling('kubejs:red_ink', ['kubejs:bad_ink', Fluid.of('hexerei:blood_fluid').withAmount(1000)])
@@ -164,46 +164,46 @@ ServerEvents.recipes(event => {
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:revolution_relay')
 	], 'create:iron_sheet', [
-		event.recipes.createDeploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:repeater']),
-		event.recipes.createDeploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:redstone']),
-		event.recipes.createDeploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:redstone_torch']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:repeater']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:redstone']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_relay', 'minecraft:redstone_torch']),
 	]).transitionalItem('kubejs:incomplete_revolution_relay').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:revolution_delay')
 	], 'create:iron_sheet', [
-		event.recipes.createDeploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_delay', 'minecraft:comparator']),
-		event.recipes.createDeploying('kubejs:incomplete_revolution_delay', ['kubejs:incomplete_revolution_delay', 'minecraft:redstone']),
-		event.recipes.createDeploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_delay', 'minecraft:redstone_torch']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_delay', 'minecraft:comparator']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_delay', ['kubejs:incomplete_revolution_delay', 'minecraft:redstone']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_relay', ['kubejs:incomplete_revolution_delay', 'minecraft:redstone_torch']),
 	]).transitionalItem('kubejs:incomplete_revolution_delay').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:candy_stomach')
 	], 'kubejs:stomach_template', [
-		event.recipes.createDeploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', '#bookwyrms:scale']),
-		event.recipes.createCutting('kubejs:incomplete_stomach_template', 'kubejs:incomplete_stomach_template'),
-		event.recipes.createDeploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', 'biomancy:living_flesh']),
-		event.recipes.createDeploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', '#forge:dyes/pink']),
+		event.recipes.create.deploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', '#bookwyrms:scale']),
+		event.recipes.create.cutting('kubejs:incomplete_stomach_template', 'kubejs:incomplete_stomach_template'),
+		event.recipes.create.deploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', 'biomancy:living_flesh']),
+		event.recipes.create.deploying('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', '#forge:dyes/pink']),
 		event.recipes.create.filling('kubejs:incomplete_stomach_template', ['kubejs:incomplete_stomach_template', Fluid.of('kubejs:syrup').withAmount(500)])
 	]).transitionalItem('kubejs:incomplete_stomach_template').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:candy_heart')
 	], 'kubejs:heart_template', [
-		event.recipes.createDeploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', 'irons_spellbooks:arcane_essence']),
-		event.recipes.createCutting('kubejs:incomplete_heart_template', 'kubejs:incomplete_heart_template'),
-		event.recipes.createDeploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', 'biomancy:living_flesh']),
-		event.recipes.createDeploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', '#forge:dyes/pink']),
+		event.recipes.create.deploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', 'irons_spellbooks:arcane_essence']),
+		event.recipes.create.cutting('kubejs:incomplete_heart_template', 'kubejs:incomplete_heart_template'),
+		event.recipes.create.deploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', 'biomancy:living_flesh']),
+		event.recipes.create.deploying('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', '#forge:dyes/pink']),
 		event.recipes.create.filling('kubejs:incomplete_heart_template', ['kubejs:incomplete_heart_template', Fluid.of('kubejs:syrup').withAmount(500)])
 	]).transitionalItem('kubejs:incomplete_heart_template').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:burning_heart')
 	], 'chestcavity:blaze_core', [
-		event.recipes.createCutting('kubejs:incomplete_burning_heart', 'kubejs:incomplete_burning_heart'),
-		event.recipes.createDeploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'chestcavity:active_blaze_rod']),
-		event.recipes.createDeploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'alexsmobs:guster_eye']),
-		event.recipes.createDeploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'kubejs:fire_gem']),
+		event.recipes.create.cutting('kubejs:incomplete_burning_heart', 'kubejs:incomplete_burning_heart'),
+		event.recipes.create.deploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'chestcavity:active_blaze_rod']),
+		event.recipes.create.deploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'alexsmobs:guster_eye']),
+		event.recipes.create.deploying('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', 'kubejs:fire_gem']),
 		event.recipes.create.filling('kubejs:incomplete_burning_heart', ['kubejs:incomplete_burning_heart', Fluid.of('minecraft:lava').withAmount(500)])
 	]).transitionalItem('kubejs:incomplete_burning_heart').loops(3)
 
@@ -211,10 +211,10 @@ ServerEvents.recipes(event => {
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:furnace_core')
 	], 'chestcavity:golem_core', [
-		event.recipes.createCutting('kubejs:incomplete_furnace_core', 'kubejs:incomplete_furnace_core'),
-		event.recipes.createDeploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'minecraft:iron_block']),
-		event.recipes.createDeploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'minecraft:blast_furnace']),
-		event.recipes.createDeploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'createaddition:connector']),
+		event.recipes.create.cutting('kubejs:incomplete_furnace_core', 'kubejs:incomplete_furnace_core'),
+		event.recipes.create.deploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'minecraft:iron_block']),
+		event.recipes.create.deploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'minecraft:blast_furnace']),
+		event.recipes.create.deploying('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', 'createaddition:connector']),
 		event.recipes.create.filling('kubejs:incomplete_furnace_core', ['kubejs:incomplete_furnace_core', Fluid.of('create:honey').withAmount(500)])
 	]).transitionalItem('kubejs:incomplete_furnace_core').loops(3)
 
@@ -222,10 +222,10 @@ ServerEvents.recipes(event => {
 		Item.of('kubejs:compressed_oxygen_implant').withChance(70.0),
 		Item.of('create:copper_sheet').withChance(30.0)
 	], Item.of('create:fluid_tank').strongNBT(), [
-		event.recipes.createDeploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'chestcavity:gas_bladder']),
-		event.recipes.createDeploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'createaddition:electrum_sheet']),
-		event.recipes.createDeploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'create:iron_sheet']),
-		event.recipes.createDeploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'createaddition:zinc_sheet'])
+		event.recipes.create.deploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'chestcavity:gas_bladder']),
+		event.recipes.create.deploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'createaddition:electrum_sheet']),
+		event.recipes.create.deploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'create:iron_sheet']),
+		event.recipes.create.deploying('kubejs:incomplete_compressed_oxygen_implant', ['kubejs:incomplete_compressed_oxygen_implant', 'createaddition:zinc_sheet'])
 	]).transitionalItem('kubejs:incomplete_compressed_oxygen_implant').loops(3)
 
 	event.recipes.create.sequenced_assembly([
@@ -233,9 +233,9 @@ ServerEvents.recipes(event => {
 		Item.of('minecraft:glass_pane').withChance(10.0),
 		Item.of('minecraft:glass').withChance(5.0)
 	], 'unusualprehistory:opal_block', [
-		event.recipes.createDeploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'alexsmobs:rainbow_glass']),
-		event.recipes.createDeploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'biomancy:unstable_compound']),
-		event.recipes.createDeploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'biomancy:corrosive_additive'])
+		event.recipes.create.deploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'alexsmobs:rainbow_glass']),
+		event.recipes.create.deploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'biomancy:unstable_compound']),
+		event.recipes.create.deploying('kubejs:incomplete_glass_wand', ['kubejs:incomplete_glass_wand', 'biomancy:corrosive_additive'])
 	]).transitionalItem('kubejs:incomplete_glass_wand').loops(6)
 
 	event.recipes.create.crushing([Item.of('2x minecraft:raw_iron'), Item.of('minecraft:raw_gold').withChance(0.2), Item.of('minecraft:raw_copper').withChance(0.2), Item.of('create:raw_zinc').withChance(0.2), Item.of('2x minecraft:lapis_lazuli').withChance(0.1)], 'kubejs:common_mineral_cluster').processingTime(100)
@@ -250,50 +250,50 @@ ServerEvents.recipes(event => {
 		Item.of('kubejs:rose_quartz_muscle').withChance(80.0),
 		Item.of('create:rose_quartz').withChance(20.0)
 	], 'kubejs:muscle_template', [
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'biomancy:rejuvenation_serum']),
-		event.recipes.createCutting('kubejs:incomplete_rose_quartz_muscle', 'kubejs:incomplete_rose_quartz_muscle'),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'minecraft:rose_bush']),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'create:polished_rose_quartz'])
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'biomancy:rejuvenation_serum']),
+		event.recipes.create.cutting('kubejs:incomplete_rose_quartz_muscle', 'kubejs:incomplete_rose_quartz_muscle'),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'minecraft:rose_bush']),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_muscle', ['kubejs:incomplete_rose_quartz_muscle', 'create:polished_rose_quartz'])
 	]).transitionalItem('kubejs:incomplete_rose_quartz_muscle').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:rose_quartz_liver').withChance(80.0),
 		Item.of('create:rose_quartz').withChance(20.0)
 	], 'kubejs:liver_template', [
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'biomancy:cleansing_serum']),
-		event.recipes.createCutting('kubejs:incomplete_rose_quartz_liver', 'kubejs:incomplete_rose_quartz_liver'),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'minecraft:rose_bush']),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'create:polished_rose_quartz'])
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'biomancy:cleansing_serum']),
+		event.recipes.create.cutting('kubejs:incomplete_rose_quartz_liver', 'kubejs:incomplete_rose_quartz_liver'),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'minecraft:rose_bush']),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_liver', ['kubejs:incomplete_rose_quartz_liver', 'create:polished_rose_quartz'])
 	]).transitionalItem('kubejs:incomplete_rose_quartz_liver').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:rose_quartz_heart').withChance(80.0),
 		Item.of('create:rose_quartz').withChance(20.0)
 	], 'kubejs:heart_template', [
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'biomancy:absorption_boost']),
-		event.recipes.createCutting('kubejs:incomplete_rose_quartz_heart', 'kubejs:incomplete_rose_quartz_heart'),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'minecraft:rose_bush']),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'create:polished_rose_quartz'])
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'biomancy:absorption_boost']),
+		event.recipes.create.cutting('kubejs:incomplete_rose_quartz_heart', 'kubejs:incomplete_rose_quartz_heart'),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'minecraft:rose_bush']),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_heart', ['kubejs:incomplete_rose_quartz_heart', 'create:polished_rose_quartz'])
 	]).transitionalItem('kubejs:incomplete_rose_quartz_heart').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:rose_quartz_dialyzer').withChance(80.0),
 		Item.of('create:rose_quartz').withChance(20.0)
 	], 'kubejs:kidney_template', [
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'biomancy:absorption_boost']),
-		event.recipes.createCutting('kubejs:incomplete_rose_quartz_dialyzer', 'kubejs:incomplete_rose_quartz_dialyzer'),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'minecraft:rose_bush']),
-		event.recipes.createDeploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'create:polished_rose_quartz'])
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'biomancy:absorption_boost']),
+		event.recipes.create.cutting('kubejs:incomplete_rose_quartz_dialyzer', 'kubejs:incomplete_rose_quartz_dialyzer'),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'minecraft:rose_bush']),
+		event.recipes.create.deploying('kubejs:incomplete_rose_quartz_dialyzer', ['kubejs:incomplete_rose_quartz_dialyzer', 'create:polished_rose_quartz'])
 	]).transitionalItem('kubejs:incomplete_rose_quartz_dialyzer').loops(5)
 
 	event.recipes.create.sequenced_assembly([
 		Item.of('kubejs:lava_life_cycle_system').withChance(75.0),
 		Item.of('chestcavity:iron_scrap').withChance(25.0)
 	], 'art_of_forging:forged_steel_ingot', [
-		event.recipes.createPressing('kubejs:incomplete_lava_life_cycle_system', 'kubejs:incomplete_lava_life_cycle_system'),
-		event.recipes.createPressing('kubejs:incomplete_lava_life_cycle_system', 'kubejs:incomplete_lava_life_cycle_system'),
-		event.recipes.createDeploying('kubejs:incomplete_lava_life_cycle_system', ['kubejs:incomplete_lava_life_cycle_system', 'create:fluid_tank']),
-		event.recipes.createDeploying('kubejs:incomplete_lava_life_cycle_system', ['kubejs:incomplete_lava_life_cycle_system', 'create:precision_mechanism']),
+		event.recipes.create.pressing('kubejs:incomplete_lava_life_cycle_system', 'kubejs:incomplete_lava_life_cycle_system'),
+		event.recipes.create.pressing('kubejs:incomplete_lava_life_cycle_system', 'kubejs:incomplete_lava_life_cycle_system'),
+		event.recipes.create.deploying('kubejs:incomplete_lava_life_cycle_system', ['kubejs:incomplete_lava_life_cycle_system', 'create:fluid_tank']),
+		event.recipes.create.deploying('kubejs:incomplete_lava_life_cycle_system', ['kubejs:incomplete_lava_life_cycle_system', 'create:precision_mechanism']),
 		event.recipes.create.filling('kubejs:incomplete_lava_life_cycle_system', ['kubejs:incomplete_lava_life_cycle_system', Fluid.of('minecraft:lava').withAmount(1000)])
 	]).transitionalItem('kubejs:incomplete_lava_life_cycle_system').loops(3)
 
@@ -301,8 +301,8 @@ ServerEvents.recipes(event => {
 		Item.of('kubejs:revolution_steam_engine').withChance(90.0),
 		Item.of('chestcavity:iron_scrap').withChance(10.0)
 	], 'create:steam_engine', [
-		event.recipes.createDeploying('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', 'art_of_forging:forged_steel_ingot']),
-		event.recipes.createDeploying('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', 'kubejs:relic_metal_plate']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', 'art_of_forging:forged_steel_ingot']),
+		event.recipes.create.deploying('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', 'kubejs:relic_metal_plate']),
 		event.recipes.create.filling('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', Fluid.of('minecraft:water').withAmount(500)]),
 		event.recipes.create.filling('kubejs:incomplete_revolution_steam_engine', ['kubejs:incomplete_revolution_steam_engine', Fluid.of('minecraft:lava').withAmount(500)])
 	]).transitionalItem('kubejs:incomplete_revolution_steam_engine').loops(3)
@@ -311,11 +311,11 @@ ServerEvents.recipes(event => {
 		Item.of('kubejs:cream_cookie_heart').withChance(50.0),
 		Item.of('minecraft:cookie').withChance(50.0)
 	], Ingredient.of('#kubejs:is_cookie_block'), [
-		event.recipes.createPressing('minecraft:cookie', 'minecraft:cookie'),
-		event.recipes.createCutting('minecraft:cookie', 'minecraft:cookie'),
+		event.recipes.create.pressing('minecraft:cookie', 'minecraft:cookie'),
+		event.recipes.create.cutting('minecraft:cookie', 'minecraft:cookie'),
 		event.recipes.create.filling('minecraft:cookie', ['minecraft:cookie', Fluid.of('kubejs:cream').withAmount(500)]),
-		event.recipes.createPressing('minecraft:cookie', 'minecraft:cookie'),
-		event.recipes.createCutting('minecraft:cookie', 'minecraft:cookie')
+		event.recipes.create.pressing('minecraft:cookie', 'minecraft:cookie'),
+		event.recipes.create.cutting('minecraft:cookie', 'minecraft:cookie')
 	]).transitionalItem('minecraft:cookie').loops(1)
 
 	event.recipes.create.crushing([Item.of('minecraft:emerald'), Item.of('minecraft:emerald').withChance(0.5)], 'geodes:emerald_crystal_block').processingTime(100)
@@ -345,12 +345,12 @@ ServerEvents.recipes(event => {
 		Item.of('kubejs:relic_metal_ingot').withChance(80.0),
 		Item.of('tetra:metal_scrap').withChance(20.0)
 	], 'art_of_forging:forged_steel_ingot', [
-		event.recipes.createDeploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
-		event.recipes.createPressing('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot'),
-		event.recipes.createDeploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
-		event.recipes.createPressing('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot'),
-		event.recipes.createDeploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
-		event.recipes.createCutting('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot')
+		event.recipes.create.deploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
+		event.recipes.create.pressing('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot'),
+		event.recipes.create.deploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
+		event.recipes.create.pressing('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot'),
+		event.recipes.create.deploying('kubejs:incomplete_relic_metal_ingot', ['kubejs:incomplete_relic_metal_ingot', 'kubejs:relic_metal_plate']),
+		event.recipes.create.cutting('kubejs:incomplete_relic_metal_ingot', 'kubejs:incomplete_relic_metal_ingot')
 	]).transitionalItem('kubejs:incomplete_relic_metal_ingot').loops(5)
 
 	event.recipes.create.sandpaper_polishing('kubejs:polished_amber', 'unusualprehistory:amber_shard')

--- a/kubejs/server_scripts/recipes/ore_excavation.js
+++ b/kubejs/server_scripts/recipes/ore_excavation.js
@@ -1,65 +1,126 @@
 ServerEvents.recipes(event => {
+  // ── Vein Definitions ─────────────────────────────────────────────────────
+  // Create Ore Excavation 1.20.1 API: veins must be defined separately from
+  // drilling recipes. placement(spacing, separation, salt) controls spawn rate.
+  // Migrated from the 4-parameter inline API used in 1.19.
+
   event.recipes.createoreexcavation
-    .drilling('iceandfire:silver_ore', '{"text": "银矿"}', 2, 600)
-    .drill('createoreexcavation:diamond_drill')
+    .vein('{"text": "银矿"}', 'iceandfire:silver_ore')
     .alwaysInfinite()
-    .stress(384)
+    .placement(1024, 256, 11111)
     .biomeWhitelist('minecraft:is_overworld')
+    .id('kubejs:vein_silver');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "青金石矿"}', 'minecraft:lapis_lazuli')
+    .alwaysInfinite()
+    .placement(512, 128, 22222)
+    .biomeWhitelist('minecraft:is_overworld')
+    .id('kubejs:vein_lapis');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "下界金矿"}', 'minecraft:gold_nugget')
+    .alwaysInfinite()
+    .placement(256, 64, 33333)
+    .biomeWhitelist('minecraft:is_nether')
+    .id('kubejs:vein_nether_gold');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "远古残骸矿"}', 'minecraft:ancient_debris')
+    .alwaysInfinite()
+    .placement(2048, 512, 44444)
+    .biomeWhitelist('minecraft:is_nether')
+    .id('kubejs:vein_netherite');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "奥术残骸矿"}', 'irons_spellbooks:arcane_debris')
+    .alwaysInfinite()
+    .placement(2048, 512, 55555)
+    .biomeWhitelist('minecraft:is_overworld')
+    .id('kubejs:vein_arcane');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "熔岩 (主世界)"}', 'minecraft:lava')
+    .alwaysInfinite()
+    .placement(256, 64, 66666)
+    .biomeWhitelist('minecraft:is_overworld')
+    .id('kubejs:vein_lava_overworld');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "熔岩 (下界)"}', 'minecraft:lava')
+    .alwaysInfinite()
+    .placement(128, 32, 77777)
+    .biomeWhitelist('minecraft:is_nether')
+    .id('kubejs:vein_lava_nether');
+
+  event.recipes.createoreexcavation
+    .vein('{"text": "水银"}', 'hexerei:quicksilver_fluid')
+    .alwaysInfinite()
+    .placement(1024, 256, 88888)
+    .biomeWhitelist('minecraft:is_overworld')
+    .id('kubejs:vein_quicksilver');
+
+  // ── Drilling Recipes ──────────────────────────────────────────────────────
+  // New signature: drilling(output(s), vein_id, extraction_time_at_32rpm)
+  // Chance outputs now use coeutil.processingOutput(item, chance_0_to_1).
+
+  event.recipes.createoreexcavation
+    .drilling('iceandfire:silver_ore', 'kubejs:vein_silver', 600)
+    .drill('createoreexcavation:diamond_drill')
+    .stress(384)
     .id('kubejs:drilling_silver');
 
   event.recipes.createoreexcavation
-    .drilling('minecraft:lapis_lazuli', '{"text": "青金石矿"}', 10, 400)
-    .alwaysInfinite()
+    .drilling('minecraft:lapis_lazuli', 'kubejs:vein_lapis', 400)
     .stress(256)
-    .biomeWhitelist('minecraft:is_overworld')
     .id('kubejs:drilling_lapis');
 
   event.recipes.createoreexcavation
-    .drilling("minecraft:gold_nugget", '{"text": "下界金矿"}', 20, 100)
-    .alwaysInfinite()
+    .drilling('minecraft:gold_nugget', 'kubejs:vein_nether_gold', 100)
     .stress(192)
-    .biomeWhitelist('minecraft:is_nether')
     .id('kubejs:drilling_nether_gold');
 
   event.recipes.createoreexcavation
-    .drilling([Item.of('minecraft:ancient_debris').withChance(0.3), Item.of('minecraft:gold_nugget').withChance(0.8), Item.of('minecraft:netherrack').withChance(0.8), Item.of('minecraft:magma_block').withChance(0.5)], '{"text": "远古残骸矿"}', 1, 4000)
+    .drilling([
+      coeutil.processingOutput('minecraft:ancient_debris', 0.3),
+      coeutil.processingOutput('minecraft:gold_nugget', 0.8),
+      coeutil.processingOutput('minecraft:netherrack', 0.8),
+      coeutil.processingOutput('minecraft:magma_block', 0.5)
+    ], 'kubejs:vein_netherite', 4000)
     .drill('createoreexcavation:netherite_drill')
-    .alwaysInfinite()
     .stress(2048)
     .fluid('minecraft:lava 500')
-    .biomeWhitelist('minecraft:is_nether')
     .id('kubejs:drilling_netherite');
 
   event.recipes.createoreexcavation
-    .drilling([Item.of('irons_spellbooks:arcane_debris').withChance(0.3), Item.of('irons_spellbooks:arcane_essence').withChance(0.8), Item.of('irons_spellbooks:cinder_essence').withChance(0.5)], '{"text": "奥术残骸矿"}', 1, 4000)
+    .drilling([
+      coeutil.processingOutput('irons_spellbooks:arcane_debris', 0.3),
+      coeutil.processingOutput('irons_spellbooks:arcane_essence', 0.8),
+      coeutil.processingOutput('irons_spellbooks:cinder_essence', 0.5)
+    ], 'kubejs:vein_arcane', 4000)
     .drill('createoreexcavation:netherite_drill')
-    .alwaysInfinite()
     .stress(2048)
     .fluid('hexerei:quicksilver_fluid 50')
-    .biomeWhitelist('minecraft:is_overworld')
     .id('kubejs:drilling_arcane');
 
+  // ── Fluid Extraction Recipes ──────────────────────────────────────────────
+  // New signature: extracting(fluid_output, vein_id, extraction_time_at_32rpm)
+
   event.recipes.createoreexcavation
-    .extracting('minecraft:lava 500', '{"text": "熔岩"}', 5, 100)
+    .extracting('minecraft:lava 500', 'kubejs:vein_lava_overworld', 100)
     .drill('createoreexcavation:diamond_drill')
-    .alwaysInfinite()
     .stress(512)
-    .biomeWhitelist('minecraft:is_overworld')
     .id('extracting_lava_overworld');
 
   event.recipes.createoreexcavation
-    .extracting('minecraft:lava 1000', '{"text": "熔岩"}', 50, 100)
+    .extracting('minecraft:lava 1000', 'kubejs:vein_lava_nether', 100)
     .drill('createoreexcavation:diamond_drill')
-    .alwaysInfinite()
     .stress(512)
-    .biomeWhitelist('minecraft:is_nether')
     .id('extracting_lava_nether');
 
   event.recipes.createoreexcavation
-    .extracting('hexerei:quicksilver_fluid 250', '{"text": "水银"}', 2, 800)
+    .extracting('hexerei:quicksilver_fluid 250', 'kubejs:vein_quicksilver', 800)
     .drill('createoreexcavation:diamond_drill')
-    .alwaysInfinite()
     .stress(640)
-    .biomeWhitelist('minecraft:is_overworld')
     .id('extracting_quicksilver');
 })

--- a/kubejs/startup_scripts/creative_tab_register.js
+++ b/kubejs/startup_scripts/creative_tab_register.js
@@ -1,3 +1,7 @@
-const $CreativeTabRegistry = Java.loadClass("dev.architectury.registry.CreativeTabRegistry")
-
-$CreativeTabRegistry.create(Utils.id("kubejs:organs"), () => Item.of("kubejs:candy_heart"))
+// KubeJS 2001 (1.20.1) creative tab API.
+// The old Architectury CreativeTabRegistry.create() approach no longer works.
+StartupEvents.registry('creative_mode_tab', event => {
+    event.create('kubejs:organs')
+        .icon(() => Item.of('kubejs:candy_heart'))
+        .displayName(Text.translatable('itemGroup.kubejs.organs'))
+})

--- a/kubejs/startup_scripts/isb/school_register.js
+++ b/kubejs/startup_scripts/isb/school_register.js
@@ -5,6 +5,7 @@ StartupEvents.registry('irons_spellbooks:schools', event => {
         .setPowerAttribute('kubejs:magnificent_spell_power')
         .setResistanceAttribute('kubejs:magnificent_spell_resistance')
         .setDefaultCastSound('irons_spellbooks:cast.generic.holy')
+        .setDamageType('minecraft:magic')  // Required in irons_spells_js 1.20.1+
 
     event.create('candy')
         .setName(Text.of(Text.translatable("school.kubejs.candy")).color('#fcc2e4'))
@@ -12,4 +13,5 @@ StartupEvents.registry('irons_spellbooks:schools', event => {
         .setPowerAttribute('kubejs:candy_spell_power')
         .setResistanceAttribute('kubejs:candy_spell_resistance')
         .setDefaultCastSound('irons_spellbooks:cast.generic.holy')
+        .setDamageType('minecraft:magic')  // Required in irons_spells_js 1.20.1+
 })

--- a/kubejs/startup_scripts/item_register.js
+++ b/kubejs/startup_scripts/item_register.js
@@ -65,7 +65,7 @@ StartupEvents.registry('item', event => {
         .tag('kubejs:organ')
         .tag('kubejs:infected')
         .tag('itemborders:iron')
-        .group("kubejs.organs")
+        .group("kubejs:organs")
 
     event.create('active_pill').texture('kubejs:item/active_pill').tag('kubejs:pill').food(food => {
         food

--- a/kubejs/startup_scripts/organ_register.js
+++ b/kubejs/startup_scripts/organ_register.js
@@ -6,7 +6,7 @@ StartupEvents.registry('item', event => {
      */
     function registerOrgan(organ) {
         global.ORGAN_LIST.push(organ)
-        let builder = event.create(organ.itemID).maxStackSize(organ.maxStackSize).tag('kubejs:organ').group("kubejs.organs")
+        let builder = event.create(organ.itemID).maxStackSize(organ.maxStackSize).tag('kubejs:organ').group("kubejs:organs")
         if (organ.ctrlTextLines.length > 0) {
             builder.tag('chestcavity:active')
         }

--- a/kubejs/startup_scripts/special/eye_finder.js
+++ b/kubejs/startup_scripts/special/eye_finder.js
@@ -1,12 +1,13 @@
 // priority: 100
 
 const $EyeofEnder = Java.loadClass('net.minecraft.world.entity.projectile.EyeOfEnder')
-const $Registry = Java.loadClass('net.minecraft.core.Registry')
+// In 1.20.1, Registry static constants moved to net.minecraft.core.registries.Registries
+const $Registries = Java.loadClass('net.minecraft.core.registries.Registries')
 const $TagKey = Java.loadClass('net.minecraft.tags.TagKey')
 
 StartupEvents.registry('item', event => {
   event.create('eye_of_fortress')
-    .group("kubejs.item")
+    .group("kubejs:organs")
     .texture('kubejs:item/eye_of_fortress')
     .use((level, player, interactionHand) => {
       return eyeFinder(level, player, interactionHand, 'kubejs:fortress_locator');
@@ -14,7 +15,7 @@ StartupEvents.registry('item', event => {
     .fireResistant();
 
   event.create('eye_of_village')
-    .group("kubejs.item")
+    .group("kubejs:organs")
     .texture('kubejs:item/eye_of_village')
     .use((level, player, interactionHand) => {
       return eyeFinder(level, player, interactionHand, 'minecraft:village');
@@ -27,7 +28,7 @@ function eyeFinder(level, player, interactionHand, structureTagString) {
   let item = player.getHeldItem(interactionHand)
   player.startUsingItem(interactionHand)
   if (!level.isClientSide()) {
-    let structureTag = $TagKey.create($Registry.STRUCTURE_REGISTRY, structureTagString)
+    let structureTag = $TagKey.create($Registries.STRUCTURE, structureTagString)
     let foundPos = level.findNearestMapStructure(structureTag, player.blockPosition(), 100, false)
     if (foundPos) {
       let eye = new $EyeofEnder(level, player.getX(), player.getY(0.5), player.getZ())

--- a/scripts/build_pack.py
+++ b/scripts/build_pack.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+build_pack.py — build distributable modpack archives from the repo.
+
+Outputs (in ./dist/):
+  *.mrpack          Modrinth format  (HMCL, Prism, MultiMC, ATLauncher)
+  *-multimc.zip     MultiMC format   (HMCL, Prism, MultiMC)
+  *-curseforge.zip  CurseForge format (HMCL, CurseForge launcher)
+
+Usage:
+  python scripts/build_pack.py [--version 0.1.0] [--out dist] [--formats all]
+
+All three formats bundle mods directly (no API look-up required).
+CurseForge's public upload portal does not allow bundled JARs, but the
+zip works fine for local import and sharing.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+PACK_NAME = "No Flesh Within Chest"
+PACK_SLUG = "no-flesh-within-chest"
+PACK_AUTHOR = "Saplyn"
+PACK_DESCRIPTION = (
+    "A high-customization organ-themed modpack based on Forge 1.20.1, "
+    "centred on ChestCavity. Includes technology, magic, and adventure elements."
+)
+
+MC_VERSION = "1.20.1"
+FORGE_VERSION = "47.3.12"  # full: 1.20.1-47.3.12
+
+# Folders copied into the instance (relative to repo root)
+OVERRIDE_DIRS = ["mods", "kubejs", "config", "defaultconfigs"]
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def sha512(path: Path) -> str:
+    h = hashlib.sha512()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha1(path: Path) -> str:
+    h = hashlib.sha1()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def collect_files(root: Path, dirs: list[str]) -> list[tuple[Path, str]]:
+    """Return (abs_path, archive_relative_path) for every file under dirs."""
+    result = []
+    for d in dirs:
+        src = root / d
+        if not src.exists():
+            print(f"  [warn] {d}/ not found, skipping", file=sys.stderr)
+            continue
+        for f in sorted(src.rglob("*")):
+            if f.is_file():
+                result.append((f, f.relative_to(root).as_posix()))
+    return result
+
+
+def progress(label: str, i: int, total: int, path: str):
+    bar_len = 30
+    filled = int(bar_len * i / total)
+    bar = "█" * filled + "░" * (bar_len - filled)
+    print(f"\r  {label} [{bar}] {i}/{total}  {Path(path).name[:40]:<40}", end="", flush=True)
+
+
+# ── Modrinth .mrpack ──────────────────────────────────────────────────────────
+
+def build_mrpack(root: Path, out: Path, version: str):
+    dest = out / f"{PACK_SLUG}-{version}.mrpack"
+    files = collect_files(root, OVERRIDE_DIRS)
+    total = len(files)
+
+    # modrinth.index.json  — mods get entries; everything else goes in overrides
+    mod_entries = []
+    override_files = []
+    for abs_path, rel in files:
+        if rel.startswith("mods/"):
+            mod_entries.append({
+                "path": rel,
+                "hashes": {
+                    "sha512": sha512(abs_path),
+                    "sha1": sha1(abs_path),
+                },
+                # No "downloads" URL — mods are bundled in overrides instead.
+                # This is valid for local/private packs; public Modrinth listings
+                # should replace this with proper project download URLs.
+                "fileSize": abs_path.stat().st_size,
+                "env": {"client": "required", "server": "required"},
+            })
+            override_files.append((abs_path, "overrides/" + rel))
+        else:
+            override_files.append((abs_path, "overrides/" + rel))
+
+    index = {
+        "formatVersion": 1,
+        "game": "minecraft",
+        "versionId": version,
+        "name": PACK_NAME,
+        "summary": PACK_DESCRIPTION,
+        "files": mod_entries,
+        "dependencies": {
+            "minecraft": MC_VERSION,
+            "forge": FORGE_VERSION,
+        },
+    }
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        zf.writestr("modrinth.index.json", json.dumps(index, indent=2, ensure_ascii=False))
+        for i, (abs_path, arc_path) in enumerate(override_files, 1):
+            progress("mrpack ", i, len(override_files), arc_path)
+            zf.write(abs_path, arc_path)
+    print(f"\n  → {dest.name}  ({dest.stat().st_size / 1e6:.1f} MB)")
+    return dest
+
+
+# ── MultiMC / Prism zip ───────────────────────────────────────────────────────
+
+MMC_PACK_JSON = {
+    "components": [
+        {"important": True, "uid": "net.minecraft", "version": MC_VERSION},
+        {"uid": "net.minecraftforge", "version": FORGE_VERSION},
+    ],
+    "formatVersion": 1,
+}
+
+INSTANCE_CFG = f"""\
+InstanceType=OneSix
+name={PACK_NAME}
+iconKey=default
+"""
+
+
+def build_multimc(root: Path, out: Path, version: str):
+    dest = out / f"{PACK_SLUG}-{version}-multimc.zip"
+    files = collect_files(root, OVERRIDE_DIRS)
+    instance_prefix = f"{PACK_SLUG}/"
+    mc_prefix = instance_prefix + ".minecraft/"
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        zf.writestr(instance_prefix + "mmc-pack.json",
+                    json.dumps(MMC_PACK_JSON, indent=2))
+        zf.writestr(instance_prefix + "instance.cfg", INSTANCE_CFG)
+        for i, (abs_path, rel) in enumerate(files, 1):
+            arc = mc_prefix + rel
+            progress("multimc", i, len(files), arc)
+            zf.write(abs_path, arc)
+    print(f"\n  → {dest.name}  ({dest.stat().st_size / 1e6:.1f} MB)")
+    return dest
+
+
+# ── CurseForge zip ────────────────────────────────────────────────────────────
+
+def build_curseforge(root: Path, out: Path, version: str):
+    dest = out / f"{PACK_SLUG}-{version}-curseforge.zip"
+    files = collect_files(root, OVERRIDE_DIRS)
+
+    # CurseForge manifest — mods listed without CF project IDs since we don't
+    # have them. They are bundled in overrides/mods/ instead, which works for
+    # local launcher import but not for public CurseForge pack upload.
+    manifest = {
+        "minecraft": {
+            "version": MC_VERSION,
+            "modLoaders": [{"id": f"forge-{FORGE_VERSION}", "primary": True}],
+        },
+        "manifestType": "minecraftModpack",
+        "manifestVersion": 1,
+        "name": PACK_NAME,
+        "version": version,
+        "author": PACK_AUTHOR,
+        "files": [],  # empty: mods are in overrides/mods
+        "overrides": "overrides",
+    }
+
+    modlist_lines = ["<ul>"]
+    for abs_path, rel in files:
+        if rel.startswith("mods/"):
+            modlist_lines.append(f"  <li>{Path(rel).name}</li>")
+    modlist_lines.append("</ul>")
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        zf.writestr("modlist.html", "\n".join(modlist_lines))
+        for i, (abs_path, rel) in enumerate(files, 1):
+            arc = "overrides/" + rel
+            progress("cfforge", i, len(files), arc)
+            zf.write(abs_path, arc)
+    print(f"\n  → {dest.name}  ({dest.stat().st_size / 1e6:.1f} MB)")
+    return dest
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(description="Build modpack distribution archives.")
+    parser.add_argument("--version", default="0.1.0",
+                        help="Pack version string (default: 0.1.0)")
+    parser.add_argument("--out", default="dist",
+                        help="Output directory (default: dist/)")
+    parser.add_argument("--formats", default="all",
+                        help="Comma-separated: mrpack,multimc,curseforge  or 'all'")
+    args = parser.parse_args()
+
+    out = repo_root / args.out
+    out.mkdir(parents=True, exist_ok=True)
+
+    chosen = {f.strip() for f in args.formats.split(",")} if args.formats != "all" \
+        else {"mrpack", "multimc", "curseforge"}
+
+    print(f"Building {PACK_NAME} v{args.version}  →  {out}/")
+    print()
+
+    results = {}
+    if "mrpack" in chosen:
+        print("Modrinth .mrpack")
+        results["mrpack"] = build_mrpack(repo_root, out, args.version)
+    if "multimc" in chosen:
+        print("MultiMC/Prism zip")
+        results["multimc"] = build_multimc(repo_root, out, args.version)
+    if "curseforge" in chosen:
+        print("CurseForge zip")
+        results["curseforge"] = build_curseforge(repo_root, out, args.version)
+
+    print()
+    print("Done. Files in", out)
+    for fmt, path in results.items():
+        size_mb = path.stat().st_size / 1e6
+        print(f"  {fmt:<12} {path.name}  ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Update launcher manifest version strings: MC 1.19.2 → 1.20.1, Forge 43.3.5 → 47.3.12, MCP 20220805 → 20230612
- Rewrite ore_excavation.js for Create Ore Excavation 1.20+ split vein/drilling API with coeutil.processingOutput()
- Update create.js: Fluid.water(n) → Fluid.of('minecraft:water').withAmount(n); migrate createDeploying/createCutting/createPressing shorthand to create.deploying/cutting/pressing namespace
- Migrate creative_tab_register.js from Architectury CreativeTabRegistry to KubeJS 2001 StartupEvents.registry API
- Fix group IDs: kubejs.organs → kubejs:organs in item_register.js, organ_register.js, eye_finder.js
- Update eye_finder.js: Registry.STRUCTURE_REGISTRY → Registries.STRUCTURE (1.20.1 core API)
- Add .setDamageType('minecraft:magic') to spell schools in school_register.js (required by irons_spells_js 1.20.1+)
- Document remaining manual steps (mod JAR replacements, manifest regeneration) in KNOWNISSUE.md

https://claude.ai/code/session_017tKAnBoESGakHk1U5KBkdC